### PR TITLE
Update ovs datapath settings for antrea version 0.11.3 and 0.13.3

### DIFF
--- a/addons/packages/antrea/0.11.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/0.11.3/bundle/config/overlay/antrea_overlay.yaml
@@ -35,9 +35,7 @@ featureGates:
 #! - netdev
 #! 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 #! OVS in userspace mode. Userspace mode requires the tun device driver to be available.
-#@ if values.infraProvider == "docker":
-ovsDatapathType: system
-#@ end
+#!ovsDatapathType: system
 
 #! Name of the interface antrea-agent will create and use for host <--> pod communication.
 #! Make sure it doesn't conflict with your existing interfaces.
@@ -169,8 +167,13 @@ metadata:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
 
 
-#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "antrea-agent"}})
+#@overlay/match by=overlay.subset({"kind":"DaemonSet","metadata":{"name": "antrea-agent"}})
 ---
+kind: DaemonSet
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
 spec:
   template:
     spec:

--- a/addons/packages/antrea/0.11.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/0.11.3/bundle/config/overlay/antrea_overlay.yaml
@@ -36,7 +36,7 @@ featureGates:
 #! 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 #! OVS in userspace mode. Userspace mode requires the tun device driver to be available.
 #@ if values.infraProvider == "docker":
-ovsDatapathType: netdev
+ovsDatapathType: system
 #@ end
 
 #! Name of the interface antrea-agent will create and use for host <--> pod communication.
@@ -169,44 +169,15 @@ metadata:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
 
 
-#@overlay/match by=overlay.subset({"kind":"DaemonSet","metadata":{"name": "antrea-agent"}})
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata": {"name": "antrea-agent"}})
 ---
-kind: DaemonSet
-metadata:
-  #@overlay/match missing_ok=True
-  annotations:
-    kapp.k14s.io/disable-default-label-scoping-rules: ""
 spec:
   template:
     spec:
-      containers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - command:
-          #@overlay/match by=overlay.subset("start_ovs")
-          #@overlay/replace
-            - start_ovs_netdev
-
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - volumeMounts:
-          #@overlay/append
-            - mountPath: /dev/net/tun
-              name: dev-tun
-        #@ end
-
       initContainers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"install-cni"})
-        - command:
-          #@overlay/match by=overlay.subset("install_cni")
-          #@overlay/replace
-            - install_cni_kind
-        #@ end
-      volumes:
-      #@ if values.infraProvider == "docker":
-      #@overlay/append
-        - hostPath:
-            path: /dev/net/tun
-            type: CharDevice
-          name: dev-tun
-      #@ end
+      #@overlay/match by=overlay.subset({"name": "install-cni"})
+      - name: install-cni
+        volumeMounts:
+        #@overlay/match by=overlay.subset({"name": "host-depmod"})
+        #@overlay/remove
+        - name host-depmod

--- a/addons/packages/antrea/0.13.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/0.13.3/bundle/config/overlay/antrea_overlay.yaml
@@ -43,9 +43,7 @@ featureGates:
 #! - netdev
 #! 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 #! OVS in userspace mode. Userspace mode requires the tun device driver to be available.
-#@ if values.infraProvider == "docker":
-ovsDatapathType: system
-#@ end
+#!ovsDatapathType: system
 
 #! Name of the interface antrea-agent will create and use for host <--> pod communication.
 #! Make sure it doesn't conflict with your existing interfaces.
@@ -211,6 +209,14 @@ data:
 kind: Deployment
 metadata:
   name: antrea-controller
+  #@overlay/match missing_ok=True
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet","metadata":{"name": "antrea-agent"}})
+---
+kind: DaemonSet
+metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""

--- a/addons/packages/antrea/0.13.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/addons/packages/antrea/0.13.3/bundle/config/overlay/antrea_overlay.yaml
@@ -44,7 +44,7 @@ featureGates:
 #! 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
 #! OVS in userspace mode. Userspace mode requires the tun device driver to be available.
 #@ if values.infraProvider == "docker":
-ovsDatapathType: netdev
+ovsDatapathType: system
 #@ end
 
 #! Name of the interface antrea-agent will create and use for host <--> pod communication.
@@ -214,46 +214,3 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
-
-
-#@overlay/match by=overlay.subset({"kind":"DaemonSet","metadata":{"name": "antrea-agent"}})
----
-kind: DaemonSet
-metadata:
-  #@overlay/match missing_ok=True
-  annotations:
-    kapp.k14s.io/disable-default-label-scoping-rules: ""
-spec:
-  template:
-    spec:
-      containers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - command:
-          #@overlay/match by=overlay.subset("start_ovs")
-          #@overlay/replace
-            - start_ovs_netdev
-
-        #@overlay/match by=overlay.subset({"name":"antrea-ovs"})
-        - volumeMounts:
-          #@overlay/append
-            - mountPath: /dev/net/tun
-              name: dev-tun
-        #@ end
-
-      initContainers:
-        #@ if values.infraProvider == "docker":
-        #@overlay/match by=overlay.subset({"name":"install-cni"})
-        - command:
-          #@overlay/match by=overlay.subset("install_cni")
-          #@overlay/replace
-            - install_cni_kind
-        #@ end
-      volumes:
-      #@ if values.infraProvider == "docker":
-      #@overlay/append
-        - hostPath:
-            path: /dev/net/tun
-            type: CharDevice
-          name: dev-tun
-      #@ end


### PR DESCRIPTION
For version 0.11.3, the depmod volume mount also was removed to avoid dependency error
in the container.

Signed-off-by: Hang Yan <yhang@vmware.com>

## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for the Release Notes (PLEASE PROVIDE)
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note

```

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
